### PR TITLE
Return error to prevent endless track reconciliation

### DIFF
--- a/pkg/rtc/errors.go
+++ b/pkg/rtc/errors.go
@@ -19,4 +19,5 @@ var (
 	ErrTrackNotFound         = errors.New("track cannot be found")
 	ErrTrackNotAttached      = errors.New("track is not yet attached")
 	ErrTrackNotBound         = errors.New("track not bound")
+	ErrTrackNotNeeded        = errors.New("track not needed")
 )

--- a/pkg/rtc/mediatracksubscriptions.go
+++ b/pkg/rtc/mediatracksubscriptions.go
@@ -91,17 +91,17 @@ func (t *MediaTrackSubscriptions) AddSubscriber(sub types.LocalParticipant, wr *
 	if sub.Identity() == "livekit-bridge" {
 		if t.params.MediaTrack.Kind() == livekit.TrackType_VIDEO {
 			t.params.Logger.Infow("livekit-bridge does not need to subscribe to video tracks")
-			return nil, nil
+			return nil, ErrTrackNotNeeded
 		}
 	} else {
 		if t.params.MediaTrack.Kind() == livekit.TrackType_AUDIO {
 			if t.params.MediaTrack.PublisherIdentity() != "livekit-bridge" {
 				t.params.Logger.Infow("Not allowed to subscribe to non livekit-bridge track")
-				return nil, nil
+				return nil, ErrTrackNotNeeded
 			}
 			if t.params.MediaTrack.Name() != string(sub.Identity()) {
 				t.params.Logger.Infow("Not allowed to subscribe to another user track")
-				return nil, nil
+				return nil, ErrTrackNotNeeded
 			}
 		}
 	}

--- a/pkg/rtc/subscriptionmanager.go
+++ b/pkg/rtc/subscriptionmanager.go
@@ -293,6 +293,11 @@ func (m *SubscriptionManager) reconcileSubscription(s *trackSubscription) {
 				if s.durationSinceStart() > subscriptionTimeout {
 					s.maybeRecordError(m.params.Telemetry, m.params.Participant.ID(), err, true)
 				}
+			case ErrTrackNotNeeded:
+				// this error is artificial and created by us
+				// it informs SubscriptionManager that the current subscriber does not need the track from the publisher
+				s.logger.Infow("subscription to track not needed", "error", err)
+				s.setDesired(false)
 			case ErrTrackNotFound:
 				// source track was never published or closed
 				// if after timeout, we'd unsubscribe from it.


### PR DESCRIPTION
Livekit 1.3.5 added a track reconciliation loop that occurs every 3s, which means it endlessly tries to stitch tracks together:
```
Mar 21 18:19:01 ip-10-2-18-107 livekit-server[3386]: 2023-03-21T18:19:01.964Z        INFO        livekit        rtc/mediatracksubscriptions.go:90        Adding subscriber        {"room": "wss://167941531036euja4j.jacktrip.cloud", "roomID": "RM_GfHrGDiT4uc2", "participant": "google-oauth2|109145711530830190463", "pID": "PA_PKFgb3SNCw4u", "remote": false, "trackID": "TR_VCg8RHQpZ3zL5A", "relayed": false, "me": "livekit-bridge", "pubID": "PA_PKFgb3SNCw4u", "pubName": "google-oauth2|109145711530830190463", "kind": "VIDEO"}
Mar 21 18:19:01 ip-10-2-18-107 livekit-server[3386]: 2023-03-21T18:19:01.964Z        INFO        livekit        rtc/mediatracksubscriptions.go:93        livekit-bridge does not need to subscribe to video tracks        {"room": "wss://167941531036euja4j.jacktrip.cloud", "roomID": "RM_GfHrGDiT4uc2", "participant": "google-oauth2|109145711530830190463", "pID": "PA_PKFgb3SNCw4u", "remote": false, "trackID": "TR_VCg8RHQpZ3zL5A", "relayed": false}
Mar 21 18:19:04 ip-10-2-18-107 livekit-server[3386]: 2023-03-21T18:19:04.965Z        INFO        livekit        rtc/mediatracksubscriptions.go:90        Adding subscriber        {"room": "wss://167941531036euja4j.jacktrip.cloud", "roomID": "RM_GfHrGDiT4uc2", "participant": "google-oauth2|109145711530830190463", "pID": "PA_PKFgb3SNCw4u", "remote": false, "trackID": "TR_VCg8RHQpZ3zL5A", "relayed": false, "me": "livekit-bridge", "pubID": "PA_PKFgb3SNCw4u", "pubName": "google-oauth2|109145711530830190463", "kind": "VIDEO"}
Mar 21 18:19:04 ip-10-2-18-107 livekit-server[3386]: 2023-03-21T18:19:04.965Z        INFO        livekit        rtc/mediatracksubscriptions.go:93        livekit-bridge does not need to subscribe to video tracks        {"room": "wss://167941531036euja4j.jacktrip.cloud", "roomID": "RM_GfHrGDiT4uc2", "participant": "google-oauth2|109145711530830190463", "pID": "PA_PKFgb3SNCw4u", "remote": false, "trackID": "TR_VCg8RHQpZ3zL5A", "relayed": false}
Mar 21 18:19:07 ip-10-2-18-107 livekit-server[3386]: 2023-03-21T18:19:07.964Z        INFO        livekit        rtc/mediatracksubscriptions.go:90        Adding subscriber        {"room": "wss://167941531036euja4j.jacktrip.cloud", "roomID": "RM_GfHrGDiT4uc2", "participant": "google-oauth2|109145711530830190463", "pID": "PA_PKFgb3SNCw4u", "remote": false, "trackID": "TR_VCg8RHQpZ3zL5A", "relayed": false, "me": "livekit-bridge", "pubID": "PA_PKFgb3SNCw4u", "pubName": "google-oauth2|109145711530830190463", "kind": "VIDEO"}
Mar 21 18:19:07 ip-10-2-18-107 livekit-server[3386]: 2023-03-21T18:19:07.964Z        INFO        livekit        rtc/mediatracksubscriptions.go:93        livekit-bridge does not need to subscribe to video tracks        {"room": "wss://167941531036euja4j.jacktrip.cloud", "roomID": "RM_GfHrGDiT4uc2", "participant": "google-oauth2|109145711530830190463", "pID": "PA_PKFgb3SNCw4u", "remote": false, "trackID": "TR_VCg8RHQpZ3zL5A", "relayed": false}
```

This causes some errors when leaving a session, so I'm introducing our a new error type to break this loop.