### PR TITLE
Prevent egress-service from subscribing to audio tracks

### DIFF
--- a/pkg/rtc/mediatracksubscriptions.go
+++ b/pkg/rtc/mediatracksubscriptions.go
@@ -93,6 +93,11 @@ func (t *MediaTrackSubscriptions) AddSubscriber(sub types.LocalParticipant, wr *
 			t.params.Logger.Infow("livekit-bridge does not need to subscribe to video tracks")
 			return nil, ErrTrackNotNeeded
 		}
+	} else if sub.Identity() == "egress-service" {
+		if t.params.MediaTrack.Kind() == livekit.TrackType_AUDIO {
+			t.params.Logger.Infow("egress-service does not need to subscribe to audio tracks")
+			return nil, ErrTrackNotNeeded
+		}
 	} else {
 		if t.params.MediaTrack.Kind() == livekit.TrackType_AUDIO {
 			if t.params.MediaTrack.PublisherIdentity() != "livekit-bridge" {


### PR DESCRIPTION
There's a case where if a participant joins via webrtc, `egress-service` will subscribe to that participant's audio track and the `livekit-bridge` audio track.

This should fix that behavior by forcing `egress-service` to only subscribe to video tracks (which in practice is all that it really needs):
```
Jul 11 16:31:57 ip-10-2-19-164 livekit-server[1259]: 2023-07-11T16:31:57.345Z        INFO        livekit        rtc/mediatracksubscriptions.go:90        Adding subscriber        {"room": "wss://1689092927k03plrlt.jacktrip.cloud", "roomID": "RM_mVQ74oTnJThN", "participant": "livekit-bridge", "pID": "PA_Y4wKjx7rYuJc", "remote": false, "trackID": "TR_AMcuU9nv2f4FRN", "relayed": false, "me": "egress-service", "pubID": "PA_Y4wKjx7rYuJc", "pubName": "livekit-bridge", "kind": "AUDIO"}
Jul 11 16:31:57 ip-10-2-19-164 livekit-server[1259]: 2023-07-11T16:31:57.345Z        INFO        livekit        rtc/mediatracksubscriptions.go:98        egress-service does not need to subscribe to audio tracks        {"room": "wss://1689092927k03plrlt.jacktrip.cloud", "roomID": "RM_mVQ74oTnJThN", "participant": "livekit-bridge", "pID": "PA_Y4wKjx7rYuJc", "remote": false, "trackID": "TR_AMcuU9nv2f4FRN", "relayed": false}
Jul 11 16:31:57 ip-10-2-19-164 livekit-server[1259]: 2023-07-11T16:31:57.345Z        INFO        livekit        rtc/subscriptionmanager.go:299        subscription to track not needed        {"room": "wss://1689092927k03plrlt.jacktrip.cloud", "roomID": "RM_mVQ74oTnJThN", "participant": "egress-service", "pID": "PA_e54gkp7vTPXg", "remote": false, "trackID": "TR_AMcuU9nv2f4FRN", "error": "track not needed"}
Jul 11 16:31:57 ip-10-2-19-164 livekit-server[1259]: 2023-07-11T16:31:57.345Z        INFO        livekit        rtc/mediatracksubscriptions.go:90        Adding subscriber        {"room": "wss://1689092927k03plrlt.jacktrip.cloud", "roomID": "RM_mVQ74oTnJThN", "participant": "google-oauth2|109145711530830190463", "pID": "PA_BFsogxE8hwXt", "remote": false, "trackID": "TR_AMH47CyMBxcvtQ", "relayed": false, "me": "egress-service", "pubID": "PA_BFsogxE8hwXt", "pubName": "google-oauth2|109145711530830190463", "kind": "AUDIO"}
Jul 11 16:31:57 ip-10-2-19-164 livekit-server[1259]: 2023-07-11T16:31:57.345Z        INFO        livekit        rtc/mediatracksubscriptions.go:98        egress-service does not need to subscribe to audio tracks        {"room": "wss://1689092927k03plrlt.jacktrip.cloud", "roomID": "RM_mVQ74oTnJThN", "participant": "google-oauth2|109145711530830190463", "pID": "PA_BFsogxE8hwXt", "remote": false, "trackID": "TR_AMH47CyMBxcvtQ", "relayed": false}
```
