### PR TITLE
Reduce the amount of time you need to wait to reconnect

### DIFF
--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -38,7 +38,7 @@ const (
 	sdBatchSize       = 30
 	rttUpdateInterval = 5 * time.Second
 
-	disconnectCleanupDuration = 15 * time.Second
+	disconnectCleanupDuration = 250 * time.Millisecond
 	migrationWaitDuration     = 3 * time.Second
 )
 

--- a/pkg/rtc/transport.go
+++ b/pkg/rtc/transport.go
@@ -42,7 +42,7 @@ const (
 	dtlsRetransmissionInterval = 100 * time.Millisecond
 
 	iceDisconnectedTimeout = 10 * time.Second // compatible for ice-lite with firefox client
-	iceFailedTimeout       = 25 * time.Second // pion's default
+	iceFailedTimeout       = 6 * time.Second  // pion's default
 	iceKeepaliveInterval   = 2 * time.Second  // pion's default
 
 	minTcpICEConnectTimeout = 5 * time.Second


### PR DESCRIPTION
Upon encountering an app crash, the peer's webrtc connection encounters the following:
```
Feb 08 18:31:33 ip-10-2-19-186 livekit-server[1272]: 2024-02-08T18:31:33.598Z        INFO        livekit        service/rtcservice.go:352        exit ws read loop for closed connection        {"room": "wss://17074163863wkxc0ur.jacktrip.cloud", "roomID": "RM_HXysQfrWEnTF", "participant": "google-oauth2|109145711530830190463", "pID": "PA_AJkm7LMvmobg", "remote": false, "connID": "CO_6HAjviynP27H", "wsError": "websocket: close 1006 (abnormal closure): unexpected EOF"}
...
Feb 08 18:31:44 ip-10-2-19-186 livekit-server[1272]: 2024-02-08T18:31:44.594Z        DEBUG        livekit        rtc/transport.go:588        ice connection state change        {"room": "wss://17074163863wkxc0ur.jacktrip.cloud", "roomID": "RM_HXysQfrWEnTF", "participant": "google-oauth2|109145711530830190463", "pID": "PA_AJkm7LMvmobg", "remote": false, "transport": "SUBSCRIBER", "state": "disconnected"}
Feb 08 18:31:44 ip-10-2-19-186 livekit-server[1272]: 2024-02-08T18:31:44.594Z        DEBUG        livekit        rtc/transport.go:604        peer connection state change        {"room": "wss://17074163863wkxc0ur.jacktrip.cloud", "roomID": "RM_HXysQfrWEnTF", "participant": "google-oauth2|109145711530830190463", "pID": "PA_AJkm7LMvmobg", "remote": false, "transport": "SUBSCRIBER", "state": "disconnected"}
Feb 08 18:31:44 ip-10-2-19-186 livekit-server[1272]: 2024-02-08T18:31:44.935Z        DEBUG        livekit        rtc/transport.go:588        ice connection state change        {"room": "wss://17074163863wkxc0ur.jacktrip.cloud", "roomID": "RM_HXysQfrWEnTF", "participant": "google-oauth2|109145711530830190463", "pID": "PA_AJkm7LMvmobg", "remote": false, "transport": "PUBLISHER", "state": "disconnected"}
Feb 08 18:31:44 ip-10-2-19-186 livekit-server[1272]: 2024-02-08T18:31:44.935Z        DEBUG        livekit        rtc/transport.go:604        peer connection state change        {"room": "wss://17074163863wkxc0ur.jacktrip.cloud", "roomID": "RM_HXysQfrWEnTF", "participant": "google-oauth2|109145711530830190463", "pID": "PA_AJkm7LMvmobg", "remote": false, "transport": "PUBLISHER", "state": "disconnected"}
...
Feb 08 18:32:08 ip-10-2-19-186 livekit-server[1272]: 2024-02-08T18:32:08.600Z        DEBUG        livekit        rtc/transport.go:588        ice connection state change        {"room": "wss://17074163863wkxc0ur.jacktrip.cloud", "roomID": "RM_HXysQfrWEnTF", "participant": "google-oauth2|109145711530830190463", "pID": "PA_AJkm7LMvmobg", "remote": false, "transport": "SUBSCRIBER", "state": "failed"}
Feb 08 18:32:08 ip-10-2-19-186 livekit-server[1272]: 2024-02-08T18:32:08.600Z        DEBUG        livekit        rtc/transport.go:604        peer connection state change        {"room": "wss://17074163863wkxc0ur.jacktrip.cloud", "roomID": "RM_HXysQfrWEnTF", "participant": "google-oauth2|109145711530830190463", "pID": "PA_AJkm7LMvmobg", "remote": false, "transport": "SUBSCRIBER", "state": "failed"}
Feb 08 18:32:08 ip-10-2-19-186 livekit-server[1272]: 2024-02-08T18:32:08.600Z        INFO        livekit        rtc/transport.go:618        peer connection failed        {"room": "wss://17074163863wkxc0ur.jacktrip.cloud", "roomID": "RM_HXysQfrWEnTF", "participant": "google-oauth2|109145711530830190463", "pID": "PA_AJkm7LMvmobg", "remote": false, "transport": "SUBSCRIBER"}
...
Feb 08 18:32:08 ip-10-2-19-186 livekit-server[1272]: 2024-02-08T18:32:08.944Z        DEBUG        livekit        rtc/transport.go:588        ice connection state change        {"room": "wss://17074163863wkxc0ur.jacktrip.cloud", "roomID": "RM_HXysQfrWEnTF", "participant": "google-oauth2|109145711530830190463", "pID": "PA_AJkm7LMvmobg", "remote": false, "transport": "PUBLISHER", "state": "failed"}
Feb 08 18:32:08 ip-10-2-19-186 livekit-server[1272]: 2024-02-08T18:32:08.944Z        DEBUG        livekit        rtc/transport.go:604        peer connection state change        {"room": "wss://17074163863wkxc0ur.jacktrip.cloud", "roomID": "RM_HXysQfrWEnTF", "participant": "google-oauth2|109145711530830190463", "pID": "PA_AJkm7LMvmobg", "remote": false, "transport": "PUBLISHER", "state": "failed"}
Feb 08 18:32:08 ip-10-2-19-186 livekit-server[1272]: 2024-02-08T18:32:08.944Z        INFO        livekit        rtc/transport.go:618        peer connection failed        {"room": "wss://17074163863wkxc0ur.jacktrip.cloud", "roomID": "RM_HXysQfrWEnTF", "participant": "google-oauth2|109145711530830190463", "pID": "PA_AJkm7LMvmobg", "remote": false, "transport": "PUBLISHER"}
...
Feb 08 18:32:23 ip-10-2-19-186 livekit-server[1272]: 2024-02-08T18:32:23.944Z        INFO        livekit        rtc/participant.go:1360        closing disconnected participant        {"room": "wss://17074163863wkxc0ur.jacktrip.cloud", "roomID": "RM_HXysQfrWEnTF", "participant": "google-oauth2|109145711530830190463", "pID": "PA_AJkm7LMvmobg", "remote": false}
Feb 08 18:32:23 ip-10-2-19-186 livekit-server[1272]: 2024-02-08T18:32:23.944Z        INFO        livekit        rtc/participant.go:675        participant closing        {"room": "wss://17074163863wkxc0ur.jacktrip.cloud", "roomID": "RM_HXysQfrWEnTF", "participant": "google-oauth2|109145711530830190463", "pID": "PA_AJkm7LMvmobg", "remote": false, "sendLeave": true, "reason": "PEER_CONNECTION_DISCONNECTED", "isExpectedToResume": false}
...
Feb 08 18:32:23 ip-10-2-19-186 livekit-server[1272]: 2024-02-08T18:32:23.944Z        INFO        livekit        rtc/room.go:265        participant state changed        {"room": "wss://17074163863wkxc0ur.jacktrip.cloud", "roomID": "RM_HXysQfrWEnTF", "state": "DISCONNECTED", "participant": "google-oauth2|109145711530830190463", "pID": "PA_AJkm7LMvmobg", "oldState": "ACTIVE"}
Feb 08 18:32:23 ip-10-2-19-186 livekit-server[1272]: 2024-02-08T18:32:23.944Z        DEBUG        livekit        rtc/room.go:489        closing participant for removal        {"room": "wss://17074163863wkxc0ur.jacktrip.cloud", "roomID": "RM_HXysQfrWEnTF", "pID": "PA_AJkm7LMvmobg", "participant": "google-oauth2|109145711530830190463"}
...
Feb 08 18:32:23 ip-10-2-19-186 livekit-server[1272]: 2024-02-08T18:32:23.945Z        DEBUG        livekit        rtc/transport.go:588        ice connection state change        {"room": "wss://17074163863wkxc0ur.jacktrip.cloud", "roomID": "RM_HXysQfrWEnTF", "participant": "google-oauth2|109145711530830190463", "pID": "PA_AJkm7LMvmobg", "remote": false, "transport": "PUBLISHER", "state": "closed"}
Feb 08 18:32:23 ip-10-2-19-186 livekit-server[1272]: 2024-02-08T18:32:23.945Z        DEBUG        livekit        rtc/transport.go:604        peer connection state change        {"room": "wss://17074163863wkxc0ur.jacktrip.cloud", "roomID": "RM_HXysQfrWEnTF", "participant": "google-oauth2|109145711530830190463", "pID": "PA_AJkm7LMvmobg", "remote": false, "transport": "PUBLISHER", "state": "closed"}
Feb 08 18:32:23 ip-10-2-19-186 livekit-server[1272]: 2024-02-08T18:32:23.945Z        DEBUG        livekit        rtc/transport.go:1386        leaving events processor        {"room": "wss://17074163863wkxc0ur.jacktrip.cloud", "roomID": "RM_HXysQfrWEnTF", "participant": "google-oauth2|109145711530830190463", "pID": "PA_AJkm7LMvmobg", "remote": false, "transport": "SUBSCRIBER"}
Feb 08 18:32:23 ip-10-2-19-186 livekit-server[1272]: 2024-02-08T18:32:23.945Z        DEBUG        livekit        rtc/transport.go:588        ice connection state change        {"room": "wss://17074163863wkxc0ur.jacktrip.cloud", "roomID": "RM_HXysQfrWEnTF", "participant": "google-oauth2|109145711530830190463", "pID": "PA_AJkm7LMvmobg", "remote": false, "transport": "SUBSCRIBER", "state": "closed"}
Feb 08 18:32:23 ip-10-2-19-186 livekit-server[1272]: 2024-02-08T18:32:23.945Z        DEBUG        livekit        rtc/transport.go:604        peer connection state change        {"room": "wss://17074163863wkxc0ur.jacktrip.cloud", "roomID": "RM_HXysQfrWEnTF", "participant": "google-oauth2|109145711530830190463", "pID": "PA_AJkm7LMvmobg", "remote": false, "transport": "SUBSCRIBER", "state": "closed"}
```

The TLDR of those logs are as follows:
* participant abruptly disconnects (ex: crash)
* after 10s, livekit transitions the participant state to `disconnected`
* after 25s, livekit transitions the participant state to `failed`
* after 15s, livekit evicts the failed participant + transitions the participant state to `closed`

This PR changes the `iceFailedTimeout` from 25s to 6s and the `disconnectCleanupDuration` from 15s to 250ms. I didn't want to touch the `iceDisconnectedTimeout` of 10s because the comments on it seem to suggest "compatible for ice-lite with firefox client" and I don't want to break anything there...

The old e2e rejoin time was about 55s. With these changes, it is now 20s.