### PR TITLE
Disable dependency descriptor logic

### DIFF
--- a/pkg/sfu/buffer/buffer.go
+++ b/pkg/sfu/buffer/buffer.go
@@ -32,7 +32,6 @@ import (
 
 	"github.com/livekit/livekit-server/pkg/sfu/audio"
 	act "github.com/livekit/livekit-server/pkg/sfu/rtpextension/abscapturetime"
-	dd "github.com/livekit/livekit-server/pkg/sfu/rtpextension/dependencydescriptor"
 	"github.com/livekit/livekit-server/pkg/sfu/rtpstats"
 	"github.com/livekit/livekit-server/pkg/sfu/utils"
 	sutils "github.com/livekit/livekit-server/pkg/utils"
@@ -229,17 +228,19 @@ func (b *Buffer) Bind(params webrtc.RTPParameters, codec webrtc.RTPCodecCapabili
 
 	for _, ext := range params.HeaderExtensions {
 		switch ext.URI {
-		case dd.ExtensionURI:
-			if IsSvcCodec(codec.MimeType) {
-				b.ddExtID = uint8(ext.ID)
-				frc := NewFrameRateCalculatorDD(b.clockRate, b.logger)
-				for i := range b.frameRateCalculator {
-					b.frameRateCalculator[i] = frc.GetFrameRateCalculatorForSpatial(int32(i))
-				}
-				b.ddParser = NewDependencyDescriptorParser(b.ddExtID, b.logger, func(spatial, temporal int32) {
-					frc.SetMaxLayer(spatial, temporal)
-				})
-			}
+		/*
+			case dd.ExtensionURI:
+					if IsSvcCodec(codec.MimeType) {
+						b.ddExtID = uint8(ext.ID)
+						frc := NewFrameRateCalculatorDD(b.clockRate, b.logger)
+						for i := range b.frameRateCalculator {
+							b.frameRateCalculator[i] = frc.GetFrameRateCalculatorForSpatial(int32(i))
+						}
+						b.ddParser = NewDependencyDescriptorParser(b.ddExtID, b.logger, func(spatial, temporal int32) {
+							frc.SetMaxLayer(spatial, temporal)
+						})
+					}
+		*/
 
 		case sdp.AudioLevelURI:
 			b.audioLevelExtID = uint8(ext.ID)

--- a/pkg/sfu/downtrack.go
+++ b/pkg/sfu/downtrack.go
@@ -40,7 +40,6 @@ import (
 	"github.com/livekit/livekit-server/pkg/sfu/connectionquality"
 	"github.com/livekit/livekit-server/pkg/sfu/pacer"
 	act "github.com/livekit/livekit-server/pkg/sfu/rtpextension/abscapturetime"
-	dd "github.com/livekit/livekit-server/pkg/sfu/rtpextension/dependencydescriptor"
 	pd "github.com/livekit/livekit-server/pkg/sfu/rtpextension/playoutdelay"
 	"github.com/livekit/livekit-server/pkg/sfu/rtpstats"
 	"github.com/livekit/livekit-server/pkg/sfu/utils"
@@ -699,8 +698,10 @@ func (d *DownTrack) SetRTPHeaderExtensions(rtpHeaderExtensions []webrtc.RTPHeade
 			} else {
 				d.absSendTimeExtID = 0
 			}
-		case dd.ExtensionURI:
-			d.dependencyDescriptorExtID = ext.ID
+		/*
+			case dd.ExtensionURI:
+				d.dependencyDescriptorExtID = ext.ID
+		*/
 		case pd.PlayoutDelayURI:
 			d.playoutDelayExtID = ext.ID
 		case sdp.TransportCCURI:

--- a/pkg/sfu/forwarder.go
+++ b/pkg/sfu/forwarder.go
@@ -34,7 +34,6 @@ import (
 
 	"github.com/livekit/livekit-server/pkg/sfu/buffer"
 	"github.com/livekit/livekit-server/pkg/sfu/codecmunger"
-	dd "github.com/livekit/livekit-server/pkg/sfu/rtpextension/dependencydescriptor"
 	"github.com/livekit/livekit-server/pkg/sfu/rtpstats"
 	"github.com/livekit/livekit-server/pkg/sfu/videolayerselector"
 	"github.com/livekit/livekit-server/pkg/sfu/videolayerselector/temporallayerselector"
@@ -302,11 +301,13 @@ func (f *Forwarder) DetermineCodec(codec webrtc.RTPCodecCapability, extensions [
 	f.codec = codec
 
 	ddAvailable := func(exts []webrtc.RTPHeaderExtensionParameter) bool {
-		for _, ext := range exts {
-			if ext.URI == dd.ExtensionURI {
-				return true
+		/*
+			for _, ext := range exts {
+				if ext.URI == dd.ExtensionURI {
+					return true
+				}
 			}
-		}
+		*/
 		return false
 	}
 

--- a/pkg/sfu/receiver.go
+++ b/pkg/sfu/receiver.go
@@ -34,7 +34,6 @@ import (
 	"github.com/livekit/livekit-server/pkg/sfu/audio"
 	"github.com/livekit/livekit-server/pkg/sfu/buffer"
 	"github.com/livekit/livekit-server/pkg/sfu/connectionquality"
-	dd "github.com/livekit/livekit-server/pkg/sfu/rtpextension/dependencydescriptor"
 	"github.com/livekit/livekit-server/pkg/sfu/rtpstats"
 )
 
@@ -230,14 +229,16 @@ func NewWebRTCReceiver(
 	w.streamTrackerManager = NewStreamTrackerManager(logger, trackInfo, w.isSVC, w.codec.ClockRate, trackersConfig)
 	w.streamTrackerManager.SetListener(w)
 	// SVC-TODO: Handle DD for non-SVC cases???
-	if w.isSVC {
-		for _, ext := range receiver.GetParameters().HeaderExtensions {
-			if ext.URI == dd.ExtensionURI {
-				w.streamTrackerManager.AddDependencyDescriptorTrackers()
-				break
+	/*
+		if w.isSVC {
+			for _, ext := range receiver.GetParameters().HeaderExtensions {
+				if ext.URI == dd.ExtensionURI {
+					w.streamTrackerManager.AddDependencyDescriptorTrackers()
+					break
+				}
 			}
 		}
-	}
+	*/
 
 	return w
 }


### PR DESCRIPTION
This is a "fix" for the broken video forwarding when using the desktop app which results in a lot of messages like `dependency descriptor extension is not present`.

What I realized is that the desktop app is able to relay video in prod but not in test. Given that the desktop app is the same + livekit-server code is the same, it must be some effect on updating the client-side javascript libraries. 

When inspecting the RTP packets as-seen by livekit-server, I found that there was a new `HeaderExtension` that gets sent in the v2 library (likely due to [this change](https://github.com/livekit/client-sdk-js/pull/1297/files)?) but not in the v1 - specifically [this one](https://github.com/livekit/livekit/blob/v1.8.3/pkg/sfu/rtpextension/dependencydescriptor/dependencydescriptorextension.go#L72) which is referred to in this codebase as `dd.ExtensionURI`:
```
# printing out codec + params.HeaderExtensions 

# in prod
Jan 22 18:19:29 ip-10-2-25-210 livekit-server[362]: codec: {video/VP9 90000 0 profile-id=0;x-google-start-bitrate=2520;x-google-max-bitrate=3600 [{goog-remb } {transport-cc } {ccm fir} {nack } {nack pli}]}
params.HeaderExtensions: [{http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01 4} {urn:ietf:params:rtp-hdrext:sdes:rtp-stream-id 10} {urn:ietf:params:rtp-hdrext:sdes:mid 9} {urn:ietf:params:rtp-hdrext:sdes:repaired-rtp-stream-id 11}]

# in test
Jan 22 17:24:53 ip-10-2-16-216 livekit-server[226]: codec: {video/VP9 90000 0 profile-id=0 [{goog-remb } {transport-cc } {ccm fir} {nack } {nack pli}]}
params.HeaderExtensions: [{urn:ietf:params:rtp-hdrext:sdes:rtp-stream-id 10} {https://aomediacodec.github.io/av1-rtp-spec/#dependency-descriptor-rtp-header-extension 12} {http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01 3} {urn:ietf:params:rtp-hdrext:sdes:mid 4} {urn:ietf:params:rtp-hdrext:sdes:repaired-rtp-stream-id 11}]
```

When this header extension is detected, there's a bunch of changes to how forwarding/receiving is implemented. I'm guessing this is because [VP9 uses SVC](https://bloggeek.me/webrtcglossary/svc/) to send multiple quality streams as opposed to traditional simulcast and thus routing is different.

The changes in this PR allow us to use vp9 as the primary codec with the desktop app but I'm not sure if it's the correct approach. One thing I found is that when an SVC codec is used, [simulcast layers are not published](https://docs.livekit.io/client-sdk-js/interfaces/TrackPublishDefaults.html#videosimulcastlayers) because in theory, it's all contained within the SVC transmission. By disabling the detection of SVC here, it seems like we're effectively breaking the ability to support multiple video quality levels. However this seems to be how the current desktop app works anyways, so it's not really a regression.

Ultimately, the root cause of this bug seems like a chromium issue which is why it works in newer QT version (6.8) but not in the released QT version (6.2). The missing `dd.ExtensionURI` header extension in the v1 javascript library seems to have masked this issue but we're seeing it now with the v2 library.